### PR TITLE
ON-36910 # `externalId` not being used as search param in `searchSubm…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `externalId` not being used as search param in `searchSubmissions()`
+
 ## [5.1.2] - 2023-11-29
 
 ### Added

--- a/src/classes/Forms.ts
+++ b/src/classes/Forms.ts
@@ -760,6 +760,12 @@ export default class Forms extends OneBlinkAPI {
       throw new Error('formId must be a number and is required')
     }
 
+    if (typeof options.externalId === 'string') {
+      searchParams = Object.assign(searchParams, {
+        externalId: options.externalId,
+      })
+    }
+
     if (typeof options.submissionDateFrom === 'string') {
       searchParams = Object.assign(searchParams, {
         submissionDateFrom: options.submissionDateFrom,


### PR DESCRIPTION
…issions()`