### PR TITLE
AP-9753 # Added submission timestamp conditional logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ scripts
 tenants
 docs-dist
 tsconfig.tsbuildinfo
+.DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `combineWithPdfAttachments` to PDF configuration form validation
+- `SUBMISSION_TIMESTAMP` type to workflow event and approval step conditional predicates schema
 
 ## [13.2.0] - 2026-07-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `SUBMISSION_TIMESTAMP` type to workflow event and approval step conditional predicates schema
+
 ## [13.2.1] - 2026-07-23
 
 ### Added
 
 - `combineWithPdfAttachments` to PDF configuration form validation
-- `SUBMISSION_TIMESTAMP` type to workflow event and approval step conditional predicates schema
 
 ## [13.2.0] - 2026-07-09
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "@eslint/js": "^9.39.2",
         "@microsoft/eslint-plugin-sdl": "^1.1.0",
         "@oneblink/release-cli": "^4.0.0",
-        "@oneblink/types": "github:oneblink/types#AP-9750",
+        "@oneblink/types": "github:oneblink/types",
         "@types/joi": "^17.2.3",
         "@types/jsonwebtoken": "^9.0.10",
         "@types/nodemailer": "^7.0.9",
@@ -1641,7 +1641,7 @@
     },
     "node_modules/@oneblink/types": {
       "version": "1.0.0",
-      "resolved": "git+ssh://git@github.com/oneblink/types.git#0445ceed26cb754fc0362878d464a4998e1655c0",
+      "resolved": "git+ssh://git@github.com/oneblink/types.git#947d14016f0393a99338382039ace43970ac7eea",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "@eslint/js": "^9.39.2",
         "@microsoft/eslint-plugin-sdl": "^1.1.0",
         "@oneblink/release-cli": "^4.0.0",
-        "@oneblink/types": "github:oneblink/types",
+        "@oneblink/types": "github:oneblink/types#AP-9750",
         "@types/joi": "^17.2.3",
         "@types/jsonwebtoken": "^9.0.10",
         "@types/nodemailer": "^7.0.9",
@@ -1641,7 +1641,7 @@
     },
     "node_modules/@oneblink/types": {
       "version": "1.0.0",
-      "resolved": "git+ssh://git@github.com/oneblink/types.git#98615fc62dcd959b6fc1339fbe982f185bc465eb",
+      "resolved": "git+ssh://git@github.com/oneblink/types.git#0445ceed26cb754fc0362878d464a4998e1655c0",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@eslint/js": "^9.39.2",
     "@microsoft/eslint-plugin-sdl": "^1.1.0",
     "@oneblink/release-cli": "^4.0.0",
-    "@oneblink/types": "github:oneblink/types#AP-9750",
+    "@oneblink/types": "github:oneblink/types",
     "@types/joi": "^17.2.3",
     "@types/jsonwebtoken": "^9.0.10",
     "@types/nodemailer": "^7.0.9",
@@ -70,7 +70,7 @@
     "pretest": "npm run eslint && tsc --noEmit && npm run fixpack",
     "release": "oneblink-release repository --no-name",
     "test": "vitest run",
-    "types": "npm i -D github:oneblink/types#AP-9750",
+    "types": "npm i -D github:oneblink/types",
     "typescript": "tsc --noEmit",
     "update-dependents": "oneblink-release update-dependents --force"
   },

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@eslint/js": "^9.39.2",
     "@microsoft/eslint-plugin-sdl": "^1.1.0",
     "@oneblink/release-cli": "^4.0.0",
-    "@oneblink/types": "github:oneblink/types",
+    "@oneblink/types": "github:oneblink/types#AP-9750",
     "@types/joi": "^17.2.3",
     "@types/jsonwebtoken": "^9.0.10",
     "@types/nodemailer": "^7.0.9",
@@ -70,7 +70,7 @@
     "pretest": "npm run eslint && tsc --noEmit && npm run fixpack",
     "release": "oneblink-release repository --no-name",
     "test": "vitest run",
-    "types": "npm i -D github:oneblink/types",
+    "types": "npm i -D github:oneblink/types#AP-9750",
     "typescript": "tsc --noEmit",
     "update-dependents": "oneblink-release update-dependents --force"
   },

--- a/src/lib/forms-schema/index.ts
+++ b/src/lib/forms-schema/index.ts
@@ -4,7 +4,8 @@ import { htmlString, s3ConfigurationSchema } from './common.js'
 import elementSchema from './element-schema.js'
 import {
   conditionallyShowPredicates,
-  ConditionalPredicatesItemSchema,
+  ConditionalPredicateFormElementSchema,
+  ConditionalPredicateSchema,
   customCssClasses,
 } from './property-schemas.js'
 export const postSubmissionActions: FormTypes.FormPostSubmissionAction[] = [
@@ -219,7 +220,7 @@ const formEventBaseSchema = {
   requiresAllConditionallyExecutePredicates: Joi.bool().default(false),
   conditionallyExecutePredicates: Joi.when('conditionallyExecute', {
     is: true,
-    then: Joi.array().min(1).items(ConditionalPredicatesItemSchema).required(),
+    then: Joi.array().min(1).items(ConditionalPredicateSchema).required(),
     otherwise: Joi.any().strip(),
   }),
 }
@@ -739,7 +740,7 @@ const approvalStepNodeProps = {
   requiresAllConditionalPredicates: Joi.boolean().default(false),
   conditionalPredicates: Joi.when('isConditional', {
     is: true,
-    then: Joi.array().min(1).items(ConditionalPredicatesItemSchema).required(),
+    then: Joi.array().min(1).items(ConditionalPredicateSchema).required(),
     otherwise: Joi.any().strip(),
   }),
   hideApprovalDenyButton: Joi.boolean(),
@@ -867,7 +868,7 @@ const formSchema = Joi.object().keys({
     requiresAllConditionalPredicates: Joi.boolean().default(false),
     conditionalPredicates: Joi.array()
       .min(1)
-      .items(ConditionalPredicatesItemSchema)
+      .items(ConditionalPredicateFormElementSchema)
       .required(),
   }),
   disableAutosave: Joi.boolean(),

--- a/src/lib/forms-schema/property-schemas.ts
+++ b/src/lib/forms-schema/property-schemas.ts
@@ -159,7 +159,7 @@ const requiresAllConditionallyShowPredicates = Joi.when('conditionallyShow', {
   otherwise: Joi.any().strip(),
 })
 
-const ConditionalPredicatesItemBaseSchema = Joi.object().keys({
+const ConditionalPredicateFormElementBaseSchema = Joi.object().keys({
   elementId: Joi.string().required(),
   type: Joi.string()
     .default('OPTIONS')
@@ -214,7 +214,7 @@ const ConditionalPredicatesItemBaseSchema = Joi.object().keys({
   }),
   predicate: Joi.when('type', {
     is: Joi.valid('FORM'),
-    then: Joi.link('#ConditionalPredicatesItemSchema'),
+    then: Joi.link('#ConditionalPredicateFormElementSchema'),
     otherwise: Joi.any().strip(),
   }),
   definition: Joi.when('type', {
@@ -251,21 +251,97 @@ const ConditionalPredicatesItemBaseSchema = Joi.object().keys({
   }),
 })
 
-export const ConditionalPredicatesItemSchema = Joi.object()
+/**
+ * Form element / page / enableSubmission predicates.
+ * Does not allow `SUBMISSION_TIMESTAMP` (see `@oneblink/types`
+ * `FormElementConditionalPredicate`).
+ */
+export const ConditionalPredicateFormElementSchema = Joi.object()
   .keys({
     type: Joi.string().valid('REPEATABLESET'),
     repeatableSetPredicate: Joi.when('type', {
       is: Joi.valid('REPEATABLESET'),
-      then: ConditionalPredicatesItemBaseSchema,
+      then: ConditionalPredicateFormElementBaseSchema,
       otherwise: Joi.any().strip(),
     }),
   })
-  .concat(ConditionalPredicatesItemBaseSchema)
-  .id('ConditionalPredicatesItemSchema')
+  .concat(ConditionalPredicateFormElementBaseSchema)
+  .id('ConditionalPredicateFormElementSchema')
+
+const ConditionalPredicateDateValueSchema = Joi.object({
+  compareWith: Joi.string().valid('VALUE', 'ELEMENT'),
+  value: Joi.when('compareWith', {
+    is: 'ELEMENT',
+    then: Joi.any().strip(),
+    otherwise: Joi.string().required(),
+  }),
+  formElementId: Joi.when('compareWith', {
+    is: 'ELEMENT',
+    then: Joi.string().required(),
+    otherwise: Joi.any().strip(),
+  }),
+  daysOffset: Joi.number(),
+})
+
+/**
+ * Evaluate against the form submission timestamp. Allowed on workflow events
+ * and approval steps only (`ConditionalPredicate` in `@oneblink/types`).
+ */
+export const ConditionalPredicateSubmissionTimestampSchema = Joi.object({
+  type: Joi.string().valid('SUBMISSION_TIMESTAMP').required(),
+  operator: Joi.string().valid('AFTER', 'BEFORE', 'BETWEEN').required(),
+  compareWith: Joi.when('operator', {
+    is: Joi.valid('AFTER', 'BEFORE'),
+    then: Joi.string().valid('VALUE', 'ELEMENT'),
+    otherwise: Joi.any().strip(),
+  }),
+  value: Joi.when('operator', {
+    is: Joi.valid('AFTER', 'BEFORE'),
+    then: Joi.when('compareWith', {
+      is: 'ELEMENT',
+      then: Joi.any().strip(),
+      otherwise: Joi.string().required(),
+    }),
+    otherwise: Joi.any().strip(),
+  }),
+  formElementId: Joi.when('operator', {
+    is: Joi.valid('AFTER', 'BEFORE'),
+    then: Joi.when('compareWith', {
+      is: 'ELEMENT',
+      then: Joi.string().required(),
+      otherwise: Joi.any().strip(),
+    }),
+    otherwise: Joi.any().strip(),
+  }),
+  daysOffset: Joi.when('operator', {
+    is: Joi.valid('AFTER', 'BEFORE'),
+    then: Joi.number(),
+    otherwise: Joi.any().strip(),
+  }),
+  min: Joi.when('operator', {
+    is: 'BETWEEN',
+    then: ConditionalPredicateDateValueSchema.required(),
+    otherwise: Joi.any().strip(),
+  }),
+  max: Joi.when('operator', {
+    is: 'BETWEEN',
+    then: ConditionalPredicateDateValueSchema.required(),
+    otherwise: Joi.any().strip(),
+  }),
+})
+
+/**
+ * Full conditional predicate schema including `SUBMISSION_TIMESTAMP`.
+ * Matches `ConditionalPredicate` in `@oneblink/types`.
+ */
+export const ConditionalPredicateSchema = Joi.alternatives([
+  ConditionalPredicateSubmissionTimestampSchema,
+  ConditionalPredicateFormElementSchema,
+])
 
 export const conditionallyShowPredicates = Joi.when('conditionallyShow', {
   is: true,
-  then: Joi.array().min(1).items(ConditionalPredicatesItemSchema).required(),
+  then: Joi.array().min(1).items(ConditionalPredicateFormElementSchema).required(),
   otherwise: Joi.any().strip(),
 })
 

--- a/src/lib/forms-schema/property-schemas.ts
+++ b/src/lib/forms-schema/property-schemas.ts
@@ -269,7 +269,7 @@ export const ConditionalPredicateFormElementSchema = Joi.object()
   .id('ConditionalPredicateFormElementSchema')
 
 const ConditionalPredicateDateValueSchema = Joi.object({
-  compareWith: Joi.string().valid('VALUE', 'ELEMENT'),
+  compareWith: Joi.string().valid('VALUE', 'ELEMENT').required(),
   value: Joi.when('compareWith', {
     is: 'VALUE',
     then: Joi.string().isoDate().required(),

--- a/src/lib/forms-schema/property-schemas.ts
+++ b/src/lib/forms-schema/property-schemas.ts
@@ -252,8 +252,8 @@ const ConditionalPredicateFormElementBaseSchema = Joi.object().keys({
 })
 
 /**
- * Form element / page / enableSubmission predicates.
- * Does not allow `SUBMISSION_TIMESTAMP` (see `@oneblink/types`
+ * Form element / page / enableSubmission predicates. Does not allow
+ * `SUBMISSION_TIMESTAMP` (see `@oneblink/types`
  * `FormElementConditionalPredicate`).
  */
 export const ConditionalPredicateFormElementSchema = Joi.object()
@@ -271,68 +271,38 @@ export const ConditionalPredicateFormElementSchema = Joi.object()
 const ConditionalPredicateDateValueSchema = Joi.object({
   compareWith: Joi.string().valid('VALUE', 'ELEMENT'),
   value: Joi.when('compareWith', {
-    is: 'ELEMENT',
-    then: Joi.any().strip(),
-    otherwise: Joi.string().required(),
+    is: 'VALUE',
+    then: Joi.string().isoDate().required(),
+    otherwise: Joi.any().strip(),
   }),
   formElementId: Joi.when('compareWith', {
     is: 'ELEMENT',
     then: Joi.string().required(),
     otherwise: Joi.any().strip(),
   }),
-  daysOffset: Joi.number(),
+  daysOffset: Joi.number().integer(),
 })
 
 /**
  * Evaluate against the form submission timestamp. Allowed on workflow events
  * and approval steps only (`ConditionalPredicate` in `@oneblink/types`).
  */
-export const ConditionalPredicateSubmissionTimestampSchema = Joi.object({
-  type: Joi.string().valid('SUBMISSION_TIMESTAMP').required(),
-  operator: Joi.string().valid('AFTER', 'BEFORE', 'BETWEEN').required(),
-  compareWith: Joi.when('operator', {
-    is: Joi.valid('AFTER', 'BEFORE'),
-    then: Joi.string().valid('VALUE', 'ELEMENT'),
-    otherwise: Joi.any().strip(),
+export const ConditionalPredicateSubmissionTimestampSchema = Joi.alternatives([
+  ConditionalPredicateDateValueSchema.keys({
+    type: Joi.string().valid('SUBMISSION_TIMESTAMP').required(),
+    operator: Joi.string().valid('AFTER', 'BEFORE').required(),
   }),
-  value: Joi.when('operator', {
-    is: Joi.valid('AFTER', 'BEFORE'),
-    then: Joi.when('compareWith', {
-      is: 'ELEMENT',
-      then: Joi.any().strip(),
-      otherwise: Joi.string().required(),
-    }),
-    otherwise: Joi.any().strip(),
+  Joi.object({
+    type: Joi.string().valid('SUBMISSION_TIMESTAMP').required(),
+    operator: Joi.string().valid('BETWEEN').required(),
+    min: ConditionalPredicateDateValueSchema.required(),
+    max: ConditionalPredicateDateValueSchema.required(),
   }),
-  formElementId: Joi.when('operator', {
-    is: Joi.valid('AFTER', 'BEFORE'),
-    then: Joi.when('compareWith', {
-      is: 'ELEMENT',
-      then: Joi.string().required(),
-      otherwise: Joi.any().strip(),
-    }),
-    otherwise: Joi.any().strip(),
-  }),
-  daysOffset: Joi.when('operator', {
-    is: Joi.valid('AFTER', 'BEFORE'),
-    then: Joi.number(),
-    otherwise: Joi.any().strip(),
-  }),
-  min: Joi.when('operator', {
-    is: 'BETWEEN',
-    then: ConditionalPredicateDateValueSchema.required(),
-    otherwise: Joi.any().strip(),
-  }),
-  max: Joi.when('operator', {
-    is: 'BETWEEN',
-    then: ConditionalPredicateDateValueSchema.required(),
-    otherwise: Joi.any().strip(),
-  }),
-})
+])
 
 /**
- * Full conditional predicate schema including `SUBMISSION_TIMESTAMP`.
- * Matches `ConditionalPredicate` in `@oneblink/types`.
+ * Full conditional predicate schema including `SUBMISSION_TIMESTAMP`. Matches
+ * `ConditionalPredicate` in `@oneblink/types`.
  */
 export const ConditionalPredicateSchema = Joi.alternatives([
   ConditionalPredicateSubmissionTimestampSchema,
@@ -341,7 +311,10 @@ export const ConditionalPredicateSchema = Joi.alternatives([
 
 export const conditionallyShowPredicates = Joi.when('conditionallyShow', {
   is: true,
-  then: Joi.array().min(1).items(ConditionalPredicateFormElementSchema).required(),
+  then: Joi.array()
+    .min(1)
+    .items(ConditionalPredicateFormElementSchema)
+    .required(),
   otherwise: Joi.any().strip(),
 })
 

--- a/tests/forms-schema/form-schema-conditional-logic.test.ts
+++ b/tests/forms-schema/form-schema-conditional-logic.test.ts
@@ -1413,4 +1413,222 @@ describe('Conditional Predicates', () => {
       '"enableSubmission.conditionalPredicates" is required',
     )
   })
+
+  test('should allow SUBMISSION_TIMESTAMP predicates on workflow events', () => {
+    const result = formSchema.validate(
+      {
+        name: 'submission timestamp workflow',
+        formsAppEnvironmentId: 1,
+        formsAppIds: [1],
+        organisationId: 'ORGANISATION_00000000001',
+        postSubmissionAction: 'FORMS_LIBRARY',
+        elements: [
+          {
+            id: 'b941ea2d-965c-4d40-8c1d-e5a231fc18b1',
+            name: 'Agm_Date',
+            label: 'AGM Date',
+            type: 'date',
+          },
+        ],
+        submissionEvents: [
+          {
+            type: 'PDF',
+            configuration: {
+              email: 'developers@oneblink.io',
+            },
+            conditionallyExecute: true,
+            conditionallyExecutePredicates: [
+              {
+                type: 'SUBMISSION_TIMESTAMP',
+                operator: 'BEFORE',
+                compareWith: 'ELEMENT',
+                formElementId: 'b941ea2d-965c-4d40-8c1d-e5a231fc18b1',
+                daysOffset: 30,
+              },
+              {
+                type: 'SUBMISSION_TIMESTAMP',
+                operator: 'AFTER',
+                compareWith: 'VALUE',
+                value: '2026-07-01',
+              },
+              {
+                type: 'SUBMISSION_TIMESTAMP',
+                operator: 'BETWEEN',
+                min: {
+                  compareWith: 'VALUE',
+                  value: '2026-01-01',
+                },
+                max: {
+                  compareWith: 'ELEMENT',
+                  formElementId: 'b941ea2d-965c-4d40-8c1d-e5a231fc18b1',
+                  daysOffset: -1,
+                },
+              },
+            ],
+          },
+        ],
+      },
+      {
+        abortEarly: false,
+      },
+    )
+    expect(result.error).toBe(undefined)
+  })
+
+  test('should allow SUBMISSION_TIMESTAMP predicates on approval steps', () => {
+    const result = formSchema.validate(
+      {
+        name: 'submission timestamp approval',
+        formsAppEnvironmentId: 1,
+        formsAppIds: [1],
+        organisationId: 'ORGANISATION_00000000001',
+        postSubmissionAction: 'FORMS_LIBRARY',
+        elements: [
+          {
+            id: 'b941ea2d-965c-4d40-8c1d-e5a231fc18b1',
+            name: 'Agm_Date',
+            label: 'AGM Date',
+            type: 'date',
+          },
+        ],
+        approvalSteps: [
+          {
+            type: 'STANDARD',
+            label: 'Manager',
+            group: 'managers',
+            isConditional: true,
+            conditionalPredicates: [
+              {
+                type: 'SUBMISSION_TIMESTAMP',
+                operator: 'BEFORE',
+                value: '2026-12-31',
+                daysOffset: 0,
+              },
+            ],
+          },
+        ],
+      },
+      {
+        abortEarly: false,
+      },
+    )
+    expect(result.error).toBe(undefined)
+  })
+
+  test('should reject SUBMISSION_TIMESTAMP predicates on form elements', () => {
+    const result = formSchema.validate(
+      {
+        name: 'submission timestamp element',
+        formsAppEnvironmentId: 1,
+        formsAppIds: [1],
+        organisationId: 'ORGANISATION_00000000001',
+        postSubmissionAction: 'FORMS_LIBRARY',
+        elements: [
+          {
+            id: 'b941ea2d-965c-4d40-8c1d-e5a231fc18b1',
+            name: 'Numbers',
+            label: 'Numbers',
+            type: 'number',
+          },
+          {
+            id: '8e4d819b-97fa-438d-b613-a092d38c3b23',
+            name: 'Text',
+            label: 'Text',
+            type: 'text',
+            conditionallyShow: true,
+            conditionallyShowPredicates: [
+              {
+                type: 'SUBMISSION_TIMESTAMP',
+                operator: 'AFTER',
+                value: '2026-07-01',
+              },
+            ],
+          },
+        ],
+      },
+      {
+        abortEarly: false,
+      },
+    )
+    expect(result.error?.message).toContain(
+      'conditionallyShowPredicates[0].type',
+    )
+  })
+
+  test('should reject SUBMISSION_TIMESTAMP predicates on page elements', () => {
+    const result = formSchema.validate(
+      {
+        name: 'submission timestamp page',
+        formsAppEnvironmentId: 1,
+        formsAppIds: [1],
+        organisationId: 'ORGANISATION_00000000001',
+        postSubmissionAction: 'FORMS_LIBRARY',
+        isMultiPage: true,
+        elements: [
+          {
+            id: 'page-1',
+            label: 'Page 1',
+            type: 'page',
+            conditionallyShow: true,
+            conditionallyShowPredicates: [
+              {
+                type: 'SUBMISSION_TIMESTAMP',
+                operator: 'AFTER',
+                value: '2026-07-01',
+              },
+            ],
+            elements: [
+              {
+                id: 'b941ea2d-965c-4d40-8c1d-e5a231fc18b1',
+                name: 'Numbers',
+                label: 'Numbers',
+                type: 'number',
+              },
+            ],
+          },
+        ],
+      },
+      {
+        abortEarly: false,
+      },
+    )
+    expect(result.error?.message).toContain(
+      'conditionallyShowPredicates[0].type',
+    )
+  })
+
+  test('should reject SUBMISSION_TIMESTAMP predicates on enableSubmission', () => {
+    const result = formSchema.validate(
+      {
+        name: 'submission timestamp enable submission',
+        formsAppEnvironmentId: 1,
+        formsAppIds: [1],
+        organisationId: 'ORGANISATION_00000000001',
+        postSubmissionAction: 'FORMS_LIBRARY',
+        elements: [
+          {
+            id: 'b941ea2d-965c-4d40-8c1d-e5a231fc18b1',
+            name: 'Numbers',
+            label: 'Numbers',
+            type: 'number',
+          },
+        ],
+        enableSubmission: {
+          conditionalPredicates: [
+            {
+              type: 'SUBMISSION_TIMESTAMP',
+              operator: 'AFTER',
+              value: '2026-07-01',
+            },
+          ],
+        },
+      },
+      {
+        abortEarly: false,
+      },
+    )
+    expect(result.error?.message).toContain(
+      'enableSubmission.conditionalPredicates[0].type',
+    )
+  })
 })

--- a/tests/forms-schema/form-schema-conditional-logic.test.ts
+++ b/tests/forms-schema/form-schema-conditional-logic.test.ts
@@ -1500,6 +1500,7 @@ describe('Conditional Predicates', () => {
             conditionalPredicates: [
               {
                 type: 'SUBMISSION_TIMESTAMP',
+                compareWith: 'VALUE',
                 operator: 'BEFORE',
                 value: '2026-12-31',
                 daysOffset: 0,


### PR DESCRIPTION
## Requester Checklist

Please only check the items that you have actioned. Do not check items that are not applicable to your PR.

### Implementation

- [ ] Have you tested your implementation locally?
- [ ] If applicable, has an appropriate changelog entry been added? Do not include if you are fixing/changing something that is only in the current release.
- [ ] There are no warnings that have been suppressed unnecessarily
- [ ] Have automated tests been added, or have related ones been updated to cover the change?
- [ ] Have all OneBlink dependency updates been completed (eg apps / apps-react / types etc).
- [ ] Have you ensured this change does not add unwanted dependencies?
- [ ] If this PR contains a refactor, have relevant Jira testing tasks added?
- [ ] Changes that will knowingly make the feature/bug incomplete have been commented with TODO and a description of what needs to be done to finish the feature/bug
- [ ] Any changes made to public APIs have been reflected in the documentation
- [ ] Have you isolated business logic where possible to allow for unit testing?

### Logging and Debugging

- [ ] Are the error messages, if any, informative?
- [ ] Are there enough log events and are they written in a way that allows for easy debugging?
- [ ] "Debugging" code removed
- [ ] Front-end: No erroneous `Console.WriteLines`

### Readability

- [ ] All class, variable, property and method modifiers are provided with the smallest scope possible
- [ ] New files, variables and functions are descriptive/comprehensible and named consistently.
- [ ] There is no dead code (unreachable code)
- [ ] There is no usage of [magic numbers](<https://en.wikipedia.org/wiki/Magic_number_(programming)>)
- [ ] There is no commented out code.
- [ ] In hard-to-understand areas, comments exist and describe rationale or reasons for decisions in code

### Security

- [ ] All personal data inputs are checked (for the correct type, length/size, format, and range).
- [ ] No sensitive information is logged or visible in a stacktrace
- [ ] Are authorization and authentication handled correctly?
- [ ] Is (user) input validated, sanitized, and escaped to prevent security attacks such as cross-site scripting or SQL injection?
- [ ] Is data retrieved from external APIs or libraries checked for security issues?
- [ ] Do API endpoints return appropriate status codes

## Reviewer Guide

- It is important that you understand the purpose of the PR.
- You are encouraged to engage with the requestor if you do not understand any of the proposed code changes/additions/deletions.
- Do you, the reviewer, understand what the code does? Do you think a specific expert, like a security expert or a usability expert, should look over the code before it can be accepted?
- Is a framework, API, library, or service used that should not be used? Are there alternatives you could recommend?
- Are there existing hooks/components/functions in the same code base that could be utilised?
- When reviewing tests, attempt to identify missing edge cases that may be relevant to the proposed implementation
- Ensure you check for:
  - Security
  - Scalability
  - Performance
  - Maintainability

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which predicate shapes are accepted on workflow events and approvals; misconfiguration could block or allow events/steps incorrectly if runtime evaluation is not aligned with the new schema.
> 
> **Overview**
> Adds **`SUBMISSION_TIMESTAMP`** conditional predicates to form validation so workflow events and approval steps can gate execution on the submission time (operators **AFTER**, **BEFORE**, and **BETWEEN**, with fixed ISO dates or form element dates plus optional **`daysOffset`**).
> 
> Predicate Joi schemas are split to match **`@oneblink/types`**: **`ConditionalPredicateSchema`** (timestamp + element predicates) is used for **`conditionallyExecutePredicates`** and approval **`conditionalPredicates`**, while **`ConditionalPredicateFormElementSchema`** (rename of the former item schema) still applies to element/page show rules and **`enableSubmission`**, which **cannot** use **`SUBMISSION_TIMESTAMP`**. **`@oneblink/types`** is bumped in the lockfile; changelog and tests cover allowed and rejected placements.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f176b91f1e38c6f39d8d886d410649039c42a887. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->